### PR TITLE
Add option for `accessType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ app.get('/auth/tdameritrade/callback', passport.authenticate('tdameritrade', {
     res.redirect('/secretstuff') // Successful auth
 });
 ```
+
+#### Refresh Token Requests
+Some OAuth2 providers require `access_type` set to `offline` to return a refresh token. You can do this by adding `accessType: 'offline'` into the `/callback` options.
+
+```javascript
+app.get('/auth/tdameritrade/callback', passport.authenticate('tdameritrade', {
+    failureRedirect: '/',
+    accessType: 'offline' // add it here
+}), function(req, res) {
+    res.redirect('/secretstuff') 
+});
+```
+
 #### Refresh Token Usage
 In some use cases where the profile may be fetched more than once or you want to keep the user authenticated, refresh tokens may wish to be used. A package such as `passport-oauth2-refresh` can assist in doing this.
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -105,6 +105,26 @@ Strategy.prototype.authorizationParams = function(options) {
     return params;
 };
 
+/**
+ * Options for the token request.
+ * @typedef {Object} tokenParams
+ * @property {string} accessType
+ * /
+/**
+ * Return extra parameters to be included in the token request
+ * 
+ * @param {Object} options 
+ * @returns {Object}
+ * @api protected 
+ */
+Strategy.prototype.tokenParams = function(options) {
+  var params = {}
+  if (options.accessType) {
+    params['access_type'] = options.accessType
+  }
+  return params
+};
+
 
 /**
  * Expose `Strategy`.


### PR DESCRIPTION
### Why:
The `refreshToken` was returning as undefined.

### This commit:
Adds an option for `accessType`, as some OAuth2 providers require `access_type=offline` to return a refresh token.